### PR TITLE
feat: fix live reload for micro-frontends

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "scripts": {
     "setup": "./infra/scripts/setup_oidc.sh",
-    "dev": "nx run-many --target=serve --projects=container,headerMfe,projectListMfe",
+    "dev": "./scripts/dev-with-mfe-tags.sh",
     "build": "nx run-many --target=build --all",
     "build:prod": "nx run-many --target=build --all --exclude=\"*-e2e\"",
     "lint": "nx run-many --target=lint --all",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "private": true,
   "dependencies": {
     "@module-federation/enhanced": "^0.9.0",
+    "classnames": "^2.5.1",
     "next": "~15.2.4",
     "react": "19.0.0",
     "react-dom": "19.0.0",

--- a/scripts/dev-with-mfe-tags.sh
+++ b/scripts/dev-with-mfe-tags.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Get all projects with serve target (applications), exclude e2e and container
+REMOTES=$(nx show projects --with-target=serve --type=app 2>/dev/null | grep -vE "(container|.*-e2e)" | tr '\n' ',' | sed 's/,$//')
+
+if [ -z "$REMOTES" ]; then
+    echo "No micro-frontend projects found. Running container only..."
+    nx serve container
+else
+    echo "Found micro-frontends: $REMOTES"
+    echo "Starting container with dev-remotes: $REMOTES"
+    nx serve container --dev-remotes="$REMOTES"
+fi


### PR DESCRIPTION
- Update dev script to use dynamic MFE detection instead of hardcoded remotes
- Add automated script to discover micro-frontends with serve target
- Enable development remotes for proper live reload functionality
- Filter out container and e2e projects automatically

This resolves the issue where micro-frontends were served as static remotes, preventing live reload from working. Now all MFEs get their own dev servers with full HMR support.