### PR TITLE
fix: resolve Terraform deployment workflow failures

### DIFF
--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -165,10 +165,15 @@ jobs:
       - name: Terraform Plan
         working-directory: infra/terraform
         run: |
+          VAR_FILE="terraform-${{ vars.STAGE || 'prod' }}.tfvars"
+          echo "📄 Using variable file: ${VAR_FILE}"
           if [ -f "${VAR_FILE}" ]; then
+            echo "✅ Found variable file: ${VAR_FILE}"
             terraform plan -var-file="${VAR_FILE}" -out=tfplan
           else
-            echo "⚠️ ${VAR_FILE} not found. Planning with TF_VAR_* only."
+            echo "⚠️ ${VAR_FILE} not found. Available files:"
+            ls -la *.tfvars || true
+            echo "Planning with TF_VAR_* environment variables only."
             terraform plan -out=tfplan
           fi
         env:
@@ -378,9 +383,15 @@ jobs:
       - name: Re-plan for safety
         working-directory: infra/terraform
         run: |
+          VAR_FILE="terraform-${{ vars.STAGE || 'prod' }}.tfvars"
+          echo "📄 Using variable file: ${VAR_FILE}"
           if [ -f "${VAR_FILE}" ]; then
+            echo "✅ Found variable file: ${VAR_FILE}"
             terraform plan -var-file="${VAR_FILE}" -out=tfplan
           else
+            echo "⚠️ ${VAR_FILE} not found. Available files:"
+            ls -la *.tfvars || true
+            echo "Planning with TF_VAR_* environment variables only."
             terraform plan -out=tfplan
           fi
         env:

--- a/infra/terraform/terraform.tfvars.example
+++ b/infra/terraform/terraform.tfvars.example
@@ -28,16 +28,11 @@ create_cloudfront_distribution  = true
 create_route53_records          = false
 hosted_zone_id                  = "" # Leave empty to auto-discover, or specify if you know it
 
-# Optional: Additional tags
-tags = {
-  ManagedBy = "terraform"
-  Owner     = "your-name"
-}
-
 # Additional Tags
 tags = {
-  Owner   = "thommf"
-  Project = "portfolio"
+  ManagedBy = "terraform"
+  Owner     = "thommf"
+  Project   = "portfolio"
 }
 
 # Static Asset Cache Configuration (Optional)


### PR DESCRIPTION
- Fix undefined VAR_FILE variable in terraform plan steps that was causing exit code 1
- Add proper variable assignment and improved error handling in deploy-infra.yml
- Remove duplicate tags blocks in terraform.tfvars.example
- Add better debugging output for missing tfvars files
- Validate fixes with actionlint and act testing

🤖 Generated with [Claude Code](https://claude.ai/code)