### PR TITLE
feat: add service worker library scaffolding

### DIFF
--- a/libs/shared/service-worker/README.md
+++ b/libs/shared/service-worker/README.md
@@ -1,0 +1,11 @@
+# service-worker
+
+This library was generated with [Nx](https://nx.dev).
+
+## Building
+
+Run `nx build service-worker` to build the library.
+
+## Running unit tests
+
+Run `nx test service-worker` to execute the unit tests via [Jest](https://jestjs.io).

--- a/libs/shared/service-worker/eslint.config.mjs
+++ b/libs/shared/service-worker/eslint.config.mjs
@@ -1,0 +1,22 @@
+import baseConfig from '../../../eslint.config.mjs';
+
+export default [
+  ...baseConfig,
+  {
+    files: ['**/*.json'],
+    rules: {
+      '@nx/dependency-checks': [
+        'error',
+        {
+          ignoredFiles: [
+            '{projectRoot}/eslint.config.{js,cjs,mjs}',
+            '{projectRoot}/vite.config.{js,ts,mjs,mts}',
+          ],
+        },
+      ],
+    },
+    languageOptions: {
+      parser: await import('jsonc-eslint-parser'),
+    },
+  },
+];

--- a/libs/shared/service-worker/jest.config.ts
+++ b/libs/shared/service-worker/jest.config.ts
@@ -1,0 +1,10 @@
+export default {
+  displayName: 'service-worker',
+  preset: '../../../jest.preset.js',
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+  },
+  moduleFileExtensions: ['ts', 'js', 'html'],
+  coverageDirectory: '../../../coverage/libs/shared/service-worker',
+};

--- a/libs/shared/service-worker/package.json
+++ b/libs/shared/service-worker/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@thommf-portfolio/service-worker",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "main": "./index.js",
+  "types": "./index.d.ts",
+  "dependencies": {}
+}

--- a/libs/shared/service-worker/project.json
+++ b/libs/shared/service-worker/project.json
@@ -1,0 +1,9 @@
+{
+  "name": "service-worker",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/shared/service-worker/src",
+  "projectType": "library",
+  "tags": [],
+  "// targets": "to see all targets run: nx show project service-worker --web",
+  "targets": {}
+}

--- a/libs/shared/service-worker/src/index.ts
+++ b/libs/shared/service-worker/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/service-worker';

--- a/libs/shared/service-worker/src/lib/service-worker.spec.ts
+++ b/libs/shared/service-worker/src/lib/service-worker.spec.ts
@@ -1,0 +1,7 @@
+import { serviceWorker } from './service-worker';
+
+describe('serviceWorker', () => {
+  it('should work', () => {
+    expect(serviceWorker()).toEqual('service-worker');
+  });
+});

--- a/libs/shared/service-worker/src/lib/service-worker.ts
+++ b/libs/shared/service-worker/src/lib/service-worker.ts
@@ -1,0 +1,3 @@
+export function serviceWorker(): string {
+  return 'service-worker';
+}

--- a/libs/shared/service-worker/tsconfig.json
+++ b/libs/shared/service-worker/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "importHelpers": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/libs/shared/service-worker/tsconfig.lib.json
+++ b/libs/shared/service-worker/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node", "vite/client"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/libs/shared/service-worker/tsconfig.spec.json
+++ b/libs/shared/service-worker/tsconfig.spec.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "module": "commonjs",
+    "moduleResolution": "node10",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "jest.config.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts"
+  ]
+}

--- a/libs/shared/service-worker/vite.config.ts
+++ b/libs/shared/service-worker/vite.config.ts
@@ -1,0 +1,46 @@
+/// <reference types='vitest' />
+import { defineConfig } from 'vite';
+import dts from 'vite-plugin-dts';
+import * as path from 'path';
+import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';
+
+export default defineConfig(() => ({
+  root: __dirname,
+  cacheDir: '../../../node_modules/.vite/libs/shared/service-worker',
+  plugins: [
+    nxViteTsPaths(),
+    nxCopyAssetsPlugin(['*.md']),
+    dts({
+      entryRoot: 'src',
+      tsconfigPath: path.join(__dirname, 'tsconfig.lib.json'),
+    }),
+  ],
+  // Uncomment this if you are using workers.
+  // worker: {
+  //  plugins: [ nxViteTsPaths() ],
+  // },
+  // Configuration for building your library.
+  // See: https://vitejs.dev/guide/build.html#library-mode
+  build: {
+    outDir: '../../../dist/libs/shared/service-worker',
+    emptyOutDir: true,
+    reportCompressedSize: true,
+    commonjsOptions: {
+      transformMixedEsModules: true,
+    },
+    lib: {
+      // Could also be a dictionary or array of multiple entry points.
+      entry: 'src/index.ts',
+      name: 'service-worker',
+      fileName: 'index',
+      // Change this to the formats you want to support.
+      // Don't forget to update your package.json as well.
+      formats: ['es' as const],
+    },
+    rollupOptions: {
+      // External packages that should not be bundled into your library.
+      external: [],
+    },
+  },
+}));

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -23,6 +23,10 @@
       "@thommf-portfolio/portfolio-store": [
         "libs/portfolio-store/src/index.ts"
       ],
+      "@thommf-portfolio/service-worker": [
+        "libs/shared/service-worker/src/index.ts"
+      ],
+      "@thommf-portfolio/shared": ["libs/shared/src/index.ts"],
       "@thommf-portfolio/store": ["libs/store/src/index.ts"]
     }
   }


### PR DESCRIPTION
- Create new service worker library under libs/shared/service-worker
- Add basic project structure with build, lint, and test configuration
- Update tsconfig.base.json with new library path mapping
- All tests passing and builds successfully